### PR TITLE
Use search params for region on bench cards.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,7 +249,7 @@ function App({ data }: Props) {
           <Route
             path="/plant/:plantId/benchcard/:templateId"
             element={
-              <BenchCardViewer data={data} />
+              <BenchCardViewer data={data} searchCriteria={searchCriteria} />
             }
           />
           <Route
@@ -333,6 +333,7 @@ const PlantDetailWrapper = ({
         togglePlantFavorite={togglePlantFavorite}
         isPlantFavorite={isPlantFavorite}
         regions={data.regions}
+        searchCriteria={searchCriteria}
       />
     </div>
   );

--- a/src/Download/DownloadMenu.tsx
+++ b/src/Download/DownloadMenu.tsx
@@ -180,6 +180,7 @@ const DownloadMenu = ({
 									region={searchCriteria.city.region}
 									waterUseByCode={data.waterUseByCode}
 									qrCodeDataUrl={qrCodeDataUrl}
+									regions={data.regions}
 								/>
 							).toBlob();
 

--- a/src/Plant/BenchCardDocument.tsx
+++ b/src/Plant/BenchCardDocument.tsx
@@ -11,6 +11,7 @@ import {
 import {
   BenchCardTemplate,
   Plant,
+  Region,
   WaterUseClassification,
   WaterUseCode,
 } from "../types";
@@ -143,6 +144,7 @@ interface BenchCardDocumentProps {
   waterUseByCode: { [key: string]: WaterUseClassification };
   benchCardTemplate: BenchCardTemplate;
   qrCodeDataUrl?: string;
+  regions: Region[];
 }
 
 const BenchCardDocument = ({
@@ -151,6 +153,7 @@ const BenchCardDocument = ({
   waterUseByCode,
   benchCardTemplate,
   qrCodeDataUrl,
+  regions
 }: BenchCardDocumentProps) => {
   const p = plant;
   // Only use the provided QR code data URL - don't fall back to sync method
@@ -178,6 +181,7 @@ const BenchCardDocument = ({
   const sizeInches = benchCardTemplate.sizeInInches;
   const sizePoints = { x: sizeInches.x * 72, y: sizeInches.y * 72 };
   const logoStyle = { height: `${sizeInches.y / 5}in`, width: "auto" };
+  const regionName = regions.find(r => r.id == region)?.name || 'Unknown'; // loose match because region.id is actually a string
 
   return (
     <Document>
@@ -261,8 +265,8 @@ const BenchCardDocument = ({
                   <WaterDropRating waterUseCode={wu.code} />
                 </View>
                 <View style={{ paddingVertical: "1pt" }}>
-                  <Text style={{ fontSize: `${sizeInches.x / 11 / 4.5}in` }}>Central Valley</Text>
-                  <Text style={{ fontSize: `${sizeInches.x / 11 / 5}in` }}>(WUCOLS Region 2)</Text>
+                  <Text style={{ fontSize: `${sizeInches.x / 11 / 4.5}in` }}>{regionName}</Text>
+                  <Text style={{ fontSize: `${sizeInches.x / 11 / 5}in` }}>(WUCOLS Region {region})</Text>
                 </View>
                 <Text style={{ fontSize: `${sizeInches.x / 11 / 6}in` }}>(Source: WUCOLS IV)</Text>
               </View>

--- a/src/Plant/BenchCardViewer.tsx
+++ b/src/Plant/BenchCardViewer.tsx
@@ -3,13 +3,14 @@ import { useParams } from "react-router-dom";
 import { PDFViewer } from "@react-pdf/renderer";
 import BenchCardDocument from "./BenchCardDocument";
 import { generateQrCodeDataUrl } from "./PlantDetailQrCode";
-import { Data } from "../types";
+import { Data, SearchCriteria } from "../types";
 
 interface BenchCardViewerProps {
   data: Data;
+  searchCriteria: SearchCriteria;
 }
 
-const BenchCardViewer = ({ data }: BenchCardViewerProps) => {
+const BenchCardViewer = ({ data, searchCriteria }: BenchCardViewerProps) => {
   const { plantId, templateId } = useParams();
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string>('');
   const [loading, setLoading] = useState(true);
@@ -94,10 +95,11 @@ const BenchCardViewer = ({ data }: BenchCardViewerProps) => {
       <PDFViewer style={{ width: "100%", height: "100%" }}>
         <BenchCardDocument
           plant={plant}
-          region={2} // Default to Central Valley region
+          region={searchCriteria.city ? searchCriteria.city.region : 2} // Default to Central Valley region
           waterUseByCode={data.waterUseByCode}
           benchCardTemplate={template}
           qrCodeDataUrl={qrCodeDataUrl}
+          regions={data.regions}
         />
       </PDFViewer>
     </div>

--- a/src/Plant/PlantDetail.tsx
+++ b/src/Plant/PlantDetail.tsx
@@ -10,8 +10,10 @@ import {
   BenchCardTemplate,
   Plant,
   Region,
+  SearchCriteria,
   WaterUseClassification,
 } from "../types";
+import SearchCriteriaConverter from "../Search/search-criteria-converter";
 
 interface Props {
   plant: Plant;
@@ -22,6 +24,7 @@ interface Props {
   benchCardTemplates: BenchCardTemplate[];
   isPlantFavorite: (plant: Plant) => boolean;
   togglePlantFavorite: (plant: Plant) => void;
+  searchCriteria: SearchCriteria;
 }
 
 const PlantDetail = ({
@@ -33,6 +36,7 @@ const PlantDetail = ({
   benchCardTemplates,
   isPlantFavorite,
   togglePlantFavorite,
+  searchCriteria,
 }: Props) => {
   const [open, setOpen] = useState(false);
   const [index, setIndex] = useState(0);
@@ -53,6 +57,8 @@ const PlantDetail = ({
   const imageSize = "64px";
   let leadPhoto = plant.photos[0];
   let photoUrl = !leadPhoto ? "" : leadPhoto.small.url;
+  const qs = SearchCriteriaConverter.toQuerystring(searchCriteria);
+
 
   const webBenchCard = (
     <>
@@ -200,7 +206,7 @@ const PlantDetail = ({
                     <h4>{bct.name} Bench Card</h4>
                     <Link
                       key={bct.id}
-                      to={`/plant/${plant.id}/benchcard/${bct.id}`}
+                      to={`/plant/${plant.id}/benchcard/${bct.id}?${qs}`}
                       className="mt-3 btn btn-primary"
                       target="_blank"
                     >


### PR DESCRIPTION
Bench cards were defaulting to Central Valley even if displaying water use from a different region. I updated it be consistent with the region passed in. Also made it more consistently use search params for both bench card preview and zip download.